### PR TITLE
Give * the freedom it needs to expand

### DIFF
--- a/update-hook
+++ b/update-hook
@@ -13,7 +13,7 @@ run_hook() {
 	local hook="$1"
 	
 	if [ -d "${RELEASE}/${HOOKDIR}/${hook}" ]; then
-		for f in "${RELEASE}/${HOOKDIR}/${hook}/*"; do
+		for f in "${RELEASE}/${HOOKDIR}/${hook}/"*; do
 			exec_hook_file "$f"
 		done
 	else


### PR DESCRIPTION
Fix for #5.

Space paranoia is maintained even though the asterisk is not inside
quotes:

```
% pwd
/Users/sgoonatilleke/Desktop/a space

% ls -1
baz qux/
foo bar/
test*

% cat test
#!/bin/bash --posix

some_dir=$(pwd -P)

for f in "${some_dir}/"*; do
    echo "|${f}|"
done

% ./test
|/Users/sgoonatilleke/Desktop/a space/baz qux|
|/Users/sgoonatilleke/Desktop/a space/foo bar|
|/Users/sgoonatilleke/Desktop/a space/test|
```
