### PR TITLE
Added a FUNCS variable to hook environment for consistent sourcing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ directory which the deployment git repository (and everything else) lives
 release of the application.
 * `NEWREV` -- The SHA of the commit being deployed.
 * `OLDREV` -- The SHA of the commit being replaced.
+* `FUNCS` -- the path to `functions.sh` used by current installation
 
 The working directory of all hooks is the root of the deployment tree. 
 During the 'stop' hook, the `current` symlink will point to the previous
@@ -200,6 +201,10 @@ To help you make your hook scripts easier to write, there are some shell
 functions available to help you on your way.  To use them, merely add:
 
     . /path/to/giddyup/functions.sh
+
+or
+
+    . $FUNCS
 
 at the top of your hook script, and then call away to your heart's content.
 

--- a/functions.sh
+++ b/functions.sh
@@ -118,7 +118,7 @@ exec_hook_file() {
 	fi
 
 	if [ -x "$hook_file" ]; then
-		env - PATH="${PATH}"	 		\
+		env   PATH="${PATH}"	 		\
 		      APP_ENV="${APP_ENV}"		\
 		      ROOT="${ROOT}"			\
 		      RELEASE="${RELEASE}"		\

--- a/functions.sh
+++ b/functions.sh
@@ -124,6 +124,7 @@ exec_hook_file() {
 		      RELEASE="${RELEASE}"		\
 		      NEWREV="${NEWREV}"		\
 		      OLDREV="${OLDREV}"		\
+		      FUNCS="${FUNCS}"			\
 		      "$hook_file"
 	else
 		cat <<EOF >&2

--- a/update-hook
+++ b/update-hook
@@ -9,7 +9,9 @@
 
 set -e
 
-. "$(dirname $(readlink -f $0))/functions.sh"
+# Consistent sourcing location for hooks deployed in multiple environments.
+FUNCS="$(dirname $(readlink -f $0))/functions.sh"
+. $FUNCS
 
 REPO="$(dirname $(cd $(dirname "$0"); pwd -P))"
 ROOT="$(dirname "${REPO}")"


### PR DESCRIPTION
Previously the installation path of giddyup was duplicated in each hook
at the sourcing of functions.sh, e.g.

```
. /path/to/install/functions.sh
```

In cases where one hook was deployed to multiple environements, each
installed in different locations, this made sourcing functions.sh
impossible. Now update-hook provides giddyup hooks with FUNCS which
points to functions.sh so sourcing becomes

```
. $FUNCS
```

although the former method is not affected.
